### PR TITLE
fix: when encounter undefined query.bindings

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -23,9 +23,11 @@ function setupMockQuery({ responses = [] } = {}) {
   tracker.on('query', query => {
     let boundSQL = query.sql;
 
-    query.bindings.forEach((binding, i) => {
-      boundSQL = boundSQL.replace(`$${i + 1}`, '?');
-    });
+    if (query.bindings) {
+      query.bindings.forEach((binding, i) => {
+        boundSQL = boundSQL.replace(`$${i + 1}`, '?');
+      });
+    }
 
     const rawQuery = knex.raw(boundSQL, query.bindings).toQuery();
 


### PR DESCRIPTION
When we have `knex.batchInsert` in the migrations, with new version of the mockKnex, we received 
```
{
      sql: 'BEGIN;',
      bindings: undefined,
      transacting: true,
      response: [Function: response],
      resolve: [Function: resolve],
      reject: [Function: reject],
      step: 8
}
```
from the tracker, so the bindings is undefined and can't be iterated.

This pr avoid this issue.